### PR TITLE
fix(ci): make pip-audit blocking on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,6 @@ jobs:
         run: |
           pip install pip-audit
           pip-audit --skip-editable
-        continue-on-error: true
 
       - name: Django system check
         run: python manage.py check


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the `pip-audit` step
- Security vulnerabilities now fail the `Tests & Security` job
- Required by the new `protect-main` ruleset which enforces this check on all PRs targeting `main`

## Test plan
- [ ] Verify CI passes on this PR (no current vulnerabilities)
- [ ] Confirm `Tests & Security` check is required before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)