### PR TITLE
security: harden repo settings and fix CodeQL alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/deces/views.py
+++ b/deces/views.py
@@ -139,15 +139,17 @@ def import_data(request):
 def import_status(request, import_id):
     try:
         import_history = ImportHistory.objects.get(id=import_id)
-        return JsonResponse({
+        data = {
             'status': import_history.status,
             'status_display': import_history.get_status_display(),
             'records_processed': import_history.records_processed,
             'total_records': import_history.total_records,
-            'error_message': import_history.error_message,
             'csv_filename': import_history.csv_filename,
             'pending_errors': import_history.pending_errors
-        })
+        }
+        if request.user.is_staff:
+            data['error_message'] = import_history.error_message
+        return JsonResponse(data)
     except ImportHistory.DoesNotExist:
         return JsonResponse({'error': 'Import non trouvé'}, status=404)
 
@@ -238,8 +240,8 @@ def datagouv_available_files(request):
             data = resp.json()
             cached = data.get('resources', [])
             cache.set('datagouv_resources_v1', cached, 300)
-        except Exception as e:
-            return JsonResponse({'error': f'API data.gouv.fr indisponible : {e}'}, status=502)
+        except Exception:
+            return JsonResponse({'error': 'API data.gouv.fr indisponible'}, status=502)
 
     imported_filenames = ImportHistory.objects.filter(
         status__in=['completed', 'processing', 'checking', 'downloading']


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` — weekly version updates for pip packages and GitHub Actions
- Fix CodeQL alert #11 (`py/stack-trace-exposure`): remove `{e}` from `data.gouv.fr` API error response in `views.py:242`
- Fix CodeQL alert #4 (`py/stack-trace-exposure`): `error_message` in `import_status` API now only returned to staff users (field is populated with `str(e)` from Celery tasks)

## Manual step required
Two settings couldn't be toggled via API (likely require GitHub Advanced Security or UI-only):
- `secret_scanning_non_provider_patterns` → enable at https://github.com/zanettibo/inseedeces/settings/security_analysis
- `secret_scanning_validity_checks` → same page

## Test plan
- [ ] CI passes
- [ ] Non-staff user calling `/import-status/<id>/` does not receive `error_message` field
- [ ] Staff user still receives `error_message` field
- [ ] CodeQL re-scan closes alerts #4 and #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)