### PR TITLE
ci: build PR preview images and cleanup on close

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +18,7 @@ concurrency:
 jobs:
   test:
     name: Tests & Security
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     services:
@@ -101,3 +103,45 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-pr:
+    name: Build PR image
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.HUB_USERNAME }}
+          password: ${{ secrets.HUB_PASSWORD }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: zanettibo/inseedeces:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  cleanup-pr:
+    name: Cleanup PR image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+
+    steps:
+      - name: Delete PR image from Docker Hub
+        run: |
+          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login" \
+            -H "Content-Type: application/json" \
+            -d '{"username":"${{ secrets.HUB_USERNAME }}","password":"${{ secrets.HUB_PASSWORD }}"}' \
+            | jq -r .token)
+          HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+            -H "Authorization: Bearer $TOKEN" \
+            "https://hub.docker.com/v2/repositories/zanettibo/inseedeces/tags/pr-${{ github.event.pull_request.number }}/")
+          echo "DELETE response: $HTTP"
+          [ "$HTTP" = "204" ] || [ "$HTTP" = "404" ]


### PR DESCRIPTION
## Summary
- Add `build-pr` job: builds `zanettibo/inseedeces:pr-{NUMBER}` after tests pass on PR open/sync/reopen
- Add `cleanup-pr` job: deletes the Docker Hub tag via API when PR is closed or merged
- Add `types: [opened, synchronize, reopened, closed]` to `pull_request` trigger
- Guard `test` job with `if: github.event.action != 'closed'` to skip tests on close events

## Usage
After a PR is open and CI passes, pull the preview image:
```
docker pull zanettibo/inseedeces:pr-22
```

## Test plan
- [ ] Open a PR → `build-pr` job runs, image `pr-{N}` appears on Docker Hub
- [ ] Push a new commit to the PR → image is rebuilt
- [ ] Merge or close the PR → `cleanup-pr` job runs, tag deleted from Docker Hub (204 or 404 response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)