### PR TITLE
fix: remove duplicate DEFAULT_AUTO_FIELD and unused local vars

### DIFF
--- a/deces/tests.py
+++ b/deces/tests.py
@@ -249,8 +249,8 @@ class SearchViewTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        _commune = make_commune()
-        _pays = make_pays()
+        make_commune()
+        make_pays()
         cls.d1 = make_deces(nom='DUPONT', prenoms='JEAN', sexe='1',
                             date_naissance=date(1950, 1, 1), date_deces=date(2020, 1, 1),
                             lieu_naissance='75056', lieu_deces='75056',

--- a/insee_deces/settings.py
+++ b/insee_deces/settings.py
@@ -277,7 +277,3 @@ STORAGES = {
     },
 }
 
-# Default primary key field type
-# https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
-
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
## Summary

Followup from #24 — missed in the merge.

- Remove duplicate `DEFAULT_AUTO_FIELD` definition in `settings.py`
- Replace `_commune`/`_pays` unused locals with bare calls in `tests.py` (CodeQL doesn't respect `_` prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)