### PR TITLE
ci: only cancel in-progress runs on PRs, not main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- `cancel-in-progress` now only applies to PR runs

Automation pushes to main (Dependency Submission, etc.) were cancelling the CI run for the merge commit, causing a permanent red cross on main even when all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)